### PR TITLE
remove borders and box-shadows of tabs

### DIFF
--- a/styles/vertical-tabs.less
+++ b/styles/vertical-tabs.less
@@ -16,9 +16,14 @@
   flex-direction: column !important;
   overflow: auto !important;
   display: block !important;
+  box-shadow: none;
 
   &::-webkit-scrollbar {
     display: unset !important;
+  }
+
+  .tab:last-of-type {
+    box-shadow: none;
   }
 
   .tab {
@@ -26,6 +31,8 @@
     height: auto !important;
     flex-grow: 0 !important;
 
+    border: none;
+    
     .title {
       text-align: left !important;
     }


### PR DESCRIPTION
I removed the borders and shadows because it looks very inconsistent for the latest atom version:

![bildschirmfoto 2017-08-03 um 23 32 07](https://user-images.githubusercontent.com/6602910/28994952-29641276-79dc-11e7-8514-b8695b69842f.jpg)
![bildschirmfoto 2017-08-03 um 23 32 21](https://user-images.githubusercontent.com/6602910/28994953-2bebc16a-79dc-11e7-8b7b-899d00e7beeb.jpg)

Now:

![bildschirmfoto 2017-08-05 um 12 48 12](https://user-images.githubusercontent.com/6602910/28994965-6b98829e-79dc-11e7-91a6-3972a6168d80.jpg)
![bildschirmfoto 2017-08-05 um 12 48 25](https://user-images.githubusercontent.com/6602910/28994966-6ce58b42-79dc-11e7-8060-94b03676180b.jpg)
